### PR TITLE
Fix/job-token

### DIFF
--- a/templates/oidc/oidc-job.yaml
+++ b/templates/oidc/oidc-job.yaml
@@ -51,6 +51,7 @@ spec:
           configMap:
             name: {{ template "harbor.oidc" . }}-config
       restartPolicy: OnFailure
+      automountServiceAccountToken: {{ .Values.oidc.automountServiceAccountToken | default false }}
     {{- with .Values.core.tolerations }}
       tolerations:
 {{ toYaml . | indent 6 }}

--- a/values.yaml
+++ b/values.yaml
@@ -61,6 +61,7 @@ oidc:
   issuer: ""
   scope: "openid,profile,offline_access,groups,email"
   verifyCert: false
+  automountServiceAccountToken: false
 
 expose:
   # Set how to expose the service. Set the type as "ingress", "clusterIP", "nodePort" or "loadBalancer"


### PR DESCRIPTION
- Introduced automountServiceAccountToken field in oidc-job.yaml to control service account token mounting behavior.
- Default value is set to false if not specified in values.