### PR TITLE
chore: add .catalog/catalog-info.yaml

### DIFF
--- a/.catalog/catalog-info.yaml
+++ b/.catalog/catalog-info.yaml
@@ -1,0 +1,44 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: harbor-helm
+  title: Harbor Helm
+  description: harbor helm chart 仓库。
+  annotations:
+    # github plugin
+    github.com/project-slug: AlaudaDevops/harbor-helm
+    # 开源组件代码仓库地址，格式：${url}/${project}/${repo}
+    acp.cpaas.io/open-source-component-repo: https://github.com/goharbor/harbor-helm
+    # 开源组件的版本信息，只适用于开源组件，自研组件默认不收集版本信息,格式 ${version}
+    acp.cpaas.io/open-source-component-version: 1.18.3
+    # 开源组件的license信息,格式 ${license}
+    acp.cpaas.io/open-source-component-license: Apache-2.0
+    # 开源组件的license地址,格式 ${url}/${project}/${repo}/${license-path}
+    acp.cpaas.io/open-source-component-license_url: https://github.com/goharbor/harbor-helm/blob/main/LICENSE
+    # backstage techdocs plugin
+    backstage.io/techdocs-ref: dir:.
+    acp.cpaas.io/owner: jtcheng@alauda.io
+
+    acp.cpaas.io/functional-attributes: plugin
+spec:
+  type: service
+  system: system:devops-tools
+  lifecycle: production
+  owner: devops
+  dependsOn:
+    - component:goharbor-distribution
+    - component:distribution
+    - component:harbor-scanner-trivy
+    - component:trivy
+---
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: devops-tools
+  title: Devops Tools
+  tags:
+  - golang
+  - devops
+spec:
+  owner: devops
+  domain: devops


### PR DESCRIPTION
## Summary
- add .catalog/catalog-info.yaml for Backstage catalog registration
- keep the source-of-truth component metadata with the repository

## Testing
- yaml parse check
