### PR TITLE
fix: remediate Harbor dependency vulnerabilities

### DIFF
--- a/.tekton/all-in-one.yaml
+++ b/.tekton/all-in-one.yaml
@@ -200,10 +200,10 @@ spec:
           # download trivy and scanner-trivy
           
           # renovate: datasource=github-releases depName=trivy packageName=AlaudaDevops/trivy
-          TRIVY_VERSION=v0.68.3-alauda-4
+          TRIVY_VERSION=v0.68.3-alauda-7
           
           # renovate: datasource=github-releases depName=harbor-scanner-trivy packageName=AlaudaDevops/harbor-scanner-trivy
-          TRIVY_ADAPTER_VERSION=v0.34.3-alauda-1
+          TRIVY_ADAPTER_VERSION=v0.34.3-alauda-2
           
           # renovate: datasource=golang-version depName=go
           export GOLANG_IMAGE_VERSION=1.26.3

--- a/.tekton/all-in-one.yaml
+++ b/.tekton/all-in-one.yaml
@@ -206,7 +206,7 @@ spec:
           TRIVY_ADAPTER_VERSION=v0.34.3-alauda-1
           
           # renovate: datasource=golang-version depName=go
-          export GOLANG_IMAGE_VERSION=1.26.2
+          export GOLANG_IMAGE_VERSION=1.26.3
           
           TRIVY_DOWNLOAD_URL=https://github.com/AlaudaDevops/trivy/releases/download/${TRIVY_VERSION}/trivy_Linux_${ARCH}.tar.gz
           TRIVY_ADAPTER_DOWNLOAD_URL=https://github.com/AlaudaDevops/harbor-scanner-trivy/releases/download/${TRIVY_ADAPTER_VERSION}/harbor-scanner-trivy_${TRIVY_ADAPTER_VERSION#v}_Linux_${ARCH}.tar.gz

--- a/subtree/harbor/make/patches/patch-amd64.sh
+++ b/subtree/harbor/make/patches/patch-amd64.sh
@@ -25,7 +25,7 @@ change_base_image "tests/test-engine-image"
 # swagger
 
 # renovate: datasource=golang-version depName=go
-export GOLANG_IMAGE_VERSION=1.26.2
+export GOLANG_IMAGE_VERSION=1.26.3
 
 sed -i 's/node:16.18.0/docker-mirrors.alauda.cn\/library\/node:16.18.0/' "Makefile"
 sed -i 's/registry.npmjs.org/internal-mirrors.alauda.cn\/repository\/npm\//g' "Makefile"
@@ -67,7 +67,6 @@ cat make/photon/trivy-adapter/Dockerfile.binary
 sed -i "s/golang:1.24.6/docker-mirrors.alauda.cn\/library\/golang:${GOLANG_IMAGE_VERSION} /g" "make/photon/registry/Dockerfile.binary"
 echo "AMD64 after change the make/photon/registry/Dockerfile.binary "
 cat make/photon/registry/Dockerfile.binary
-
 
 
 

--- a/subtree/harbor/src/go.mod
+++ b/subtree/harbor/src/go.mod
@@ -91,7 +91,7 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.3.0 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
-	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect
+	github.com/Azure/go-ntlmssp v0.1.1 // indirect
 	github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Unknwon/goconfig v0.0.0-20160216183935-5f601ca6ef4d // indirect

--- a/subtree/harbor/src/go.sum
+++ b/subtree/harbor/src/go.sum
@@ -39,8 +39,9 @@ github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
-github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 h1:mFRzDkZVAjdal+s7s0MwaRv9igoPqLRdzOLzw/8Xvq8=
 github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
+github.com/Azure/go-ntlmssp v0.1.1 h1:l+FM/EEMb0U9QZE7mKNEDw5Mu3mFiaa2GKOoTSsNDPw=
+github.com/Azure/go-ntlmssp v0.1.1/go.mod h1:NYqdhxd/8aAct/s4qSYZEerdPuH1liG2/X9DiVTbhpk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=


### PR DESCRIPTION
## Summary
- Update github.com/Azure/go-ntlmssp in subtree/harbor/src.
- Update GOLANG_IMAGE_VERSION from 1.26.2 to 1.26.3 in Tekton and patch scripts.
- Keep Photon base image unchanged for now; a follow-up PR will update it after a fixed Photon tag is published.

## Verification
- GOTOOLCHAIN=auto GOPROXY=https://proxy.golang.org,direct go test ./... in subtree/harbor/src was attempted and stopped at github.com/goharbor/harbor/src/common/dao because POSTGRESQL_HOST is not set.
- Non-testing go.mod scan: only LOW github.com/jackc/pgx/v4 CVE-2026-41889 remains, with no fixed version in Trivy DB.